### PR TITLE
fix(ChordDisplay): allow keyboard key height up to 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# 1.6.0 (2023-12-11)
+# 1.6.1 (2023-12-11)
+
+## Fixes
+- **Chord Display:** allow keyboard key height up to 16
+
+# 1.6.0 (2023-12-23)
 
 ## Features
 - **Chord Display:** Fully customizable Piano (sizes, colors and labels above keys)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "midi-jar",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "midi-jar",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "midi-jar",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A MIDI tool box for displaying chords and notes, routing devices, and more",
   "main": "./src/main/main.ts",
   "scripts": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "midi-jar",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "midi-jar",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "midi-jar",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A MIDI tool box for displaying chords and notes, routing devices, and more",
   "license": "MIT",
   "author": {

--- a/src/renderer/views/Settings/ChordDisplaySettings/ChordDisplayModuleSettings.tsx
+++ b/src/renderer/views/Settings/ChordDisplaySettings/ChordDisplayModuleSettings.tsx
@@ -264,7 +264,7 @@ const ChordDisplayModuleSettings: React.FC<Props> = ({ parentPath }) => {
                 value={moduleSettings.keyboard.sizes.height}
                 onChange={(value: number) => updateModuleSetting('keyboard.sizes.height', value)}
                 min={1}
-                max={8}
+                max={16}
                 step={0.1}
                 valueText={`${moduleSettings.keyboard.sizes.height}`}
               />
@@ -277,8 +277,8 @@ const ChordDisplayModuleSettings: React.FC<Props> = ({ parentPath }) => {
                   onChange={(value: number) => updateModuleSetting('keyboard.sizes.ratio', value)}
                   min={0.1}
                   max={0.9}
-                  step={0.05}
-                  valueText={`${Math.round(moduleSettings.keyboard.sizes.ratio * 100)}%`}
+                  step={0.025}
+                  valueText={`${(moduleSettings.keyboard.sizes.ratio * 100).toFixed(1)}%`}
                 />
               </FormField>
             )}


### PR DESCRIPTION
fixes https://github.com/la-jarre-a-son/midi-jar/issues/27#issuecomment-1851140068

Keyboard Key height can be set up to 16.
Black key ratio also can be changed in 2.5% increments